### PR TITLE
Problem: test for C++11 (so g++4.9) is reqiured by this component but…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ save.xml
 # Executables
 src/fty-shm_selftest
 src/fty-shm-cleanup
-src/fty-shm-cli
 src/benchmark
+src/fty-shm-cli
 src/fty_shm_selftest
 *.exe
 *.out

--- a/configure.ac
+++ b/configure.ac
@@ -1092,7 +1092,16 @@ AS_IF([test "x$enable_Werror" = "xyes" || test "x$enable_Werror" = "xauto"],
 # One of big missing features in gcc-4.8 was std::regex support fixed in 4.9
 # Testing code from https://stackoverflow.com/a/41186162/4715872
 # caveats apply (use of unguaranteed private macros)
+AC_ARG_ENABLE([gcc-std-regex],
+    AS_HELP_STRING([--enable-gcc-std-regex],
+        [Check for std::regex support if compiler is GCC, assuming it means satisfactory level of C++11 there [default=yes]]),
+    [enable_gcc_std_regex=$enableval],
+    [enable_gcc_std_regex=$defaultval])
+
+AM_CONDITIONAL([ENABLE_GCC_STD_REGEX], [test x$enable_gcc_std_regex != xno])
+
 AS_IF([test -n "$CXX"],[AS_IF([$CXX --version 2>&1 | grep 'Free Software Foundation' > /dev/null && test "x$GCC" = "xyes"],
+  [AS_IF([test "x$enable_gcc_std_regex" = "xyes" || test "x$enable_gcc_std_regex" = "xauto"],
     [AC_MSG_CHECKING([for GNU C++11 support level expected by gcc-4.9 release or newer])
      CXXFLAGS="$CXXFLAGS --std=c++11"
      AC_LANG_PUSH([C++])
@@ -1123,9 +1132,12 @@ int main() {
 #endif
   return result ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
+     ], AC_MSG_RESULT([ok]), AC_MSG_ERROR([test for std::regex failed]) )
      AC_LANG_POP([C++])
     ]
+  ,[AC_MSG_WARN([Not checking for GNU C++11 support level expected by gcc-4.9 release or newer, due to explicit configure option])
+    AC_MSG_WARN([YOU ARE AT RISK OF SOMETHING NOT WORKING WITH THIS BUILD OF THE CODEBASE])]
+  )]
 )])
 
 # Specify output files

--- a/packaging/debian/fty-shm.install
+++ b/packaging/debian/fty-shm.install
@@ -3,5 +3,3 @@ usr/bin/fty-shm-cli
 etc/fty-shm/fty-shm-cleanup.cfg
 lib/systemd/system/fty-shm-cleanup.service
 lib/systemd/system/fty-shm-cleanup.timer
-# Note: Path to the timer unit above was fixed to match
-# the service unit and its actual installation by recipes

--- a/project.xml
+++ b/project.xml
@@ -12,7 +12,7 @@
     <target name = "debian" />
     <target name = "redhat" />
     <target name = "travis" >
-        <!-- Force to use trusty because we still depend of auto_ptr :( -->
+        <!-- Force to use trusty because we still depend on auto_ptr :( -->
         <option name = "dist" value = "trusty" />
         <option name = "shadow_gcc" value = "2" />
         <!-- option name = "clangformat_implem" value = "autotools" / -->


### PR DESCRIPTION
… not necessarily needed by its consumers in CI

Solution: make the check for std::regex optional with --enable-gcc-std-regex=no
A build with this option set should compile, but the result would not necessarily function.
If Travis tests of components require fty-shm but do not really use it (or this aspect of it) in unit-tests, this is sufficient.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

-----

Context:

After a bit of discussion, maybe there is a cleaner and less global alternative to requiring gcc-4.9 in all components, even those that do not natively need it, which would be to use customized “add_config_opts” for “use fty-shm” tags so its configure script would not check the compiler (gcc-4.8 delivers the symbols, but they are not implemented and just “return”; good enough to compile and not use in unit-tests). There is an example of “add_config_opts” in fty-nut.